### PR TITLE
CD Pipeline: Automate Publish Bentobox SDK to Pypi and Bentobox Engine Container to GHCR

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -58,6 +58,7 @@ jobs:
   publish-engine:
     runs-on: ubuntu-20.04
     name: "Publish bentobox-engine container to Github Container Registry"
+    steps:
     - uses: actions/checkout@v2
       with:
         # fetch all history for all branches and tags

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -105,4 +105,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.4.2 
         with:
           password: ${{ secrets.TEST_PYPI_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -61,15 +61,22 @@ jobs:
   publish-engine:
     runs-on: ubuntu-20.04
     name: "Publish bentobox-engine container to Github Container Registry"
+    outputs:
+      container-tag: ${{ steps.resolve-tag.outputs.container-tag }}
     steps:
     - uses: actions/checkout@v2
       with:
         # fetch all history for all branches and tags
         fetch-depth: 0
-    - name: "Build bentobox-sim"
+    - id: resolve-tag
+      name: "Resolve bentobox-engine container tag"
+      run: |
+        DOCKER_TAG=ghcr.io/bentobox-dev/bentobox-engine:$(git describe --long --always)
+        echo "::set-output name=container-tag::${DOCKER_TAG}"
+    - name: "Build bentobox-engine"
       run: |
         # build container tagged version given by git describe
-        DOCKER_TAG="ghcr.io/bentobox-dev/bentobox-engine:$(git describe --long --always)"
+        DOCKER_TAG=${{ steps.resolve-tag.outputs.container-tag }}
         make \
           SIM_BUILD_TYPE=Release \
           SIM_DOCKER_STAGE=release \
@@ -83,9 +90,10 @@ jobs:
         echo $GHCR_TOKEN | docker login ghcr.io --username $GHCR_USER --password-stdin
     - name: "Push bentobox-engine container to Github Container Registry"
       run: |
-        DOCKER_TAG="ghcr.io/bentobox-dev/bentobox-engine:$(git describe --long --always)"
+        DOCKER_TAG=${{ steps.resolve-tag.outputs.container-tag }}
         docker push $DOCKER_TAG
         
+  # build and publish the engine component on github container registry
   publish-sdk:
     runs-on: ubuntu-20.04
     name: "Publish bentobox-sdk package to Pypi"
@@ -106,6 +114,7 @@ jobs:
       - name: Publish bentobox-sdk to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2 
         with:
+          # TODO(mrzzy): publish this to actual pypi
           password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           packages_dir: sdk/dist/

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -69,13 +69,24 @@ jobs:
     - name: "Build bentobox-sim"
       run: |
         # build container tagged version given by git describe
-        VERSION=$(git describe --long --always)
+        DOCKER_TAG="ghcr.io/bentobox-dev/bentobox-engine:$(git describe --long --always)"
         make \
           SIM_BUILD_TYPE=Release \
           SIM_DOCKER_STAGE=release \
-          SIM_DOCKER="gcr.io/joeltio/bento-box/engine:${VERSION}" \
+          SIM_DOCKER=${DOCKER_TAG} \
           build-sim-docker
-
+    - name: "Authenticate with Github Container Registry"
+      env:
+        GHCR_USER: ${{secrets.GHCR_USER}}
+        GHCR_TOKEN: ${{secrets.GHCR_TOKEN}}
+      run: |
+        echo $GHCR_TOKEN | docker login ghcr.io --username $GHCR_USER --password-stdin
+    - name: "Push bentobox-engine container to Github Container Registry"
+      env:
+      run: |
+        DOCKER_TAG="ghcr.io/bentobox-dev/bentobox-engine:$(git describe --long --always)"
+        docker push $DOCKER_TAG
+        
   publish-sdk:
     runs-on: ubuntu-20.04
     name: "Publish bentobox-sdk package to Pypi"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -42,7 +42,10 @@ jobs:
           git add docs
 
           # check for staged changes to SDK docs
-          if git diff --staged --quiet then echo "No SDK Docs changes to commit." exit 0
+          if git diff --staged --quiet
+          then
+            echo "No SDK Docs changes to commit."
+            exit 0
           fi
 
           # Commit changes as Github Actions bot
@@ -66,9 +69,25 @@ jobs:
     - name: "Build bentobox-sim"
       run: |
         # build container tagged version given by git describe
-        VERSION=$(git describe --always)
+        VERSION=$(git describe --long --always)
         make \
           SIM_BUILD_TYPE=Release \
           SIM_DOCKER_STAGE=release \
-          SIM_DOCKER=gcr.io/joeltio/bento-box/engine:$(VERSION) \
+          SIM_DOCKER="gcr.io/joeltio/bento-box/engine:${VERSION}" \
           build-sim-docker
+
+  publish-sdk:
+    runs-on: ubuntu-20.04
+    name: "Publish bentobox-sdk package to Pypi"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # fetch all history for all branches and tags
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: "Build bentobox-sdk"
+        run: |
+          # build dist bentobox package to dist/
+          make build-sdk

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -72,6 +72,7 @@ jobs:
       name: "Resolve bentobox-engine container tag"
       run: |
         DOCKER_TAG=ghcr.io/bentobox-dev/bentobox-engine:$(git describe --long --always)
+        echo $DOCKER_TAG
         echo "::set-output name=container-tag::${DOCKER_TAG}"
     - name: "Build bentobox-engine"
       run: |
@@ -114,7 +115,5 @@ jobs:
       - name: Publish bentobox-sdk to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2 
         with:
-          # TODO(mrzzy): publish this to actual pypi
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_TOKEN }}
           packages_dir: sdk/dist/

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -42,10 +42,7 @@ jobs:
           git add docs
 
           # check for staged changes to SDK docs
-          if git diff --staged --quiet
-          then
-            echo "No SDK Docs changes to commit."
-            exit 0
+          if git diff --staged --quiet then echo "No SDK Docs changes to commit." exit 0
           fi
 
           # Commit changes as Github Actions bot
@@ -57,18 +54,20 @@ jobs:
           # Publish changes by pushing to Github
           git push
 
-    # build and publish the engine component on github container registry
-    publish-engine:
-      - uses: actions/checkout@v2
-        with:
-          # fetch all history for all branches and tags
-          fetch-depth: 0
-      - name: "Build bentobox-sim"
-        run: |
-          # build container tagged version given by git describe
-          VERSION=$(git describe --always)
-          make \
-            SIM_BUILD_TYPE=Release \
-            SIM_DOCKER_STAGE=release \
-            SIM_DOCKER=gcr.io/joeltio/bento-box/engine:$(VERSION) \
-            build-sim-docker
+  # build and publish the engine component on github container registry
+  publish-engine:
+    runs-on: ubuntu-20.04
+    name: "Publish bentobox-engine container to Github Container Registry"
+    - uses: actions/checkout@v2
+      with:
+        # fetch all history for all branches and tags
+        fetch-depth: 0
+    - name: "Build bentobox-sim"
+      run: |
+        # build container tagged version given by git describe
+        VERSION=$(git describe --always)
+        make \
+          SIM_BUILD_TYPE=Release \
+          SIM_DOCKER_STAGE=release \
+          SIM_DOCKER=gcr.io/joeltio/bento-box/engine:$(VERSION) \
+          build-sim-docker

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -101,3 +101,8 @@ jobs:
         run: |
           # build dist bentobox package to dist/
           make build-sdk
+      - name: Publish bentobox-sdk to Test PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.2 
+        with:
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -82,7 +82,6 @@ jobs:
       run: |
         echo $GHCR_TOKEN | docker login ghcr.io --username $GHCR_USER --password-stdin
     - name: "Push bentobox-engine container to Github Container Registry"
-      env:
       run: |
         DOCKER_TAG="ghcr.io/bentobox-dev/bentobox-engine:$(git describe --long --always)"
         docker push $DOCKER_TAG

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -99,10 +99,11 @@ jobs:
           python-version: 3.7
       - name: "Build bentobox-sdk"
         run: |
-          # build dist bentobox package to dist/
+          # build dist bentobox package to sdk/dist
           make build-sdk
       - name: Publish bentobox-sdk to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2 
         with:
           password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
+          packages_dir: sdk/dist/

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,11 +4,10 @@
 #
 
 name: "CD Pipeline"
-on:
-  push:
-    branches: {}
-        # TODO(mrzzy): remove this before commit
-        # - master
+on: push
+# TODO(mrzzy): remove this before commit
+# branches:
+# - master
 jobs:
   # builds & publishes docs for the sdk component to Github
   publish-docs-sdk:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,8 +6,9 @@
 name: "CD Pipeline"
 on:
   push:
-    branches:
-      - master
+    branches: {}
+        # TODO(mrzzy): remove this before commit
+        # - master
 jobs:
   # builds & publishes docs for the sdk component to Github
   publish-docs-sdk:
@@ -56,3 +57,19 @@ jobs:
 
           # Publish changes by pushing to Github
           git push
+
+    # build and publish the engine component on github container registry
+    publish-engine:
+      - uses: actions/checkout@v2
+        with:
+          # fetch all history for all branches and tags
+          fetch-depth: 0
+      - name: "Build bentobox-sim"
+        run: |
+          # build container tagged version given by git describe
+          VERSION=$(git describe --always)
+          make \
+            SIM_BUILD_TYPE=Release \
+            SIM_DOCKER_STAGE=release \
+            SIM_DOCKER=gcr.io/joeltio/bento-box/engine:$(VERSION) \
+            build-sim-docker

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -101,6 +101,8 @@ jobs:
         run: |
           # build dist bentobox package to sdk/dist
           make build-sdk
+          # display built artifacts
+          ls sdk/dist/
       - name: Publish bentobox-sdk to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2 
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,11 @@
 #
 
 name: "CI Pipeline"
-on: push
+on:
+  push:
+    branches:
+        # TODO(mrzzy): remove this before commit
+      - match-nothing
 jobs:
   # quick check that protos can be compiled by protoc
   # and lint proto formatting

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
   build-docs-sdk:
     needs: build-test-sdk
     runs-on: ubuntu-20.04
-    name: "Build & Push bentobox-sdk Docs"
+    name: "Build bentobox-sdk Docs"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/sdk/requirements-dev.txt
+++ b/sdk/requirements-dev.txt
@@ -32,3 +32,4 @@ typing-extensions==3.7.4.3
 zipp==3.4.0
 mypy-protobuf==2.4
 types-protobuf==0.1.1
+twine==3.3.0

--- a/sdk/setup.cfg
+++ b/sdk/setup.cfg
@@ -18,7 +18,7 @@ project_urls =
     Source Code = https://github.com/joeltio/bento-box
 license = MIT
 classifier =
-    License :: OSI Approved :: MIT
+    License :: OSI Approved :: MIT License
     Programming Language :: Python
 
 [files]


### PR DESCRIPTION
Partially Implement #29  
- Automate Publish Bentobox SDK to Pypi
- Fix name: "build & push docs" even though no pushing is involved.
- Automate Publish Bentobox Engine Container to Github Container Registry (GHCR)