### PR TITLE
Add Mypy Static Type Checking to SDK & Pull latest bentobox-engine image as build cache

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -101,7 +101,8 @@ jobs:
         # push with both latest and versioned tag
         DOCKER_TAG=${{ steps.resolve-tag.outputs.container-tag }}
         docker push $DOCKER_TAG
-        docker push "${DOCKER_REPO]:latest"
+        docker tag $DOCKER_TAG "${DOCKER_REPO}:latest"
+        docker push "${DOCKER_REPO}:latest"
 
   # deploy the engine component on GKE using the currently built image
   deploy-engine:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,12 +4,10 @@
 #
 
 name: "CD Pipeline"
-# TODO(mrzzy): remove this before commit
-#on:
-#  push:
-#    branches:
-#      - master
-on: push
+on:
+  push:
+    branches:
+      - master
 env:
   DOCKER_REPO: ghcr.io/bentobox-dev/bentobox-engine
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -12,6 +12,7 @@ name: "CD Pipeline"
 on: push
 env:
   DOCKER_REPO: ghcr.io/bentobox-dev/bentobox-engine
+  DOCKER_BUILDKIT: 1
 jobs:
   # builds & publishes docs for the sdk component to Github
   publish-docs-sdk:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -63,6 +63,7 @@ jobs:
     name: "Publish bentobox-engine container to Github Container Registry"
     outputs:
       container-tag: ${{ steps.resolve-tag.outputs.container-tag }}
+      container-repo: ${{ steps.resolve-tag.outputs.container-repo }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -71,8 +72,10 @@ jobs:
     - id: resolve-tag
       name: "Resolve bentobox-engine container tag"
       run: |
-        DOCKER_TAG=ghcr.io/bentobox-dev/bentobox-engine:$(git describe --long --always)
+        DOCKER_REPO=ghcr.io/bentobox-dev/bentobox-engine
+        DOCKER_TAG=$DOCKER_REPO:$(git describe --long --always)
         echo $DOCKER_TAG
+        echo "::set-output name=container-repo::${DOCKER_REPO}"
         echo "::set-output name=container-tag::${DOCKER_TAG}"
     - name: "Pull existing latest bentobox-engine to utilize layers as cache"
       run: |
@@ -95,8 +98,11 @@ jobs:
         echo $GHCR_TOKEN | docker login ghcr.io --username $GHCR_USER --password-stdin
     - name: "Push bentobox-engine container to Github Container Registry"
       run: |
+        # push with both latest and versioned tag
+        DOCKER_REPO=${{ steps.resolve-tag.outputs.container-repo }}
         DOCKER_TAG=${{ steps.resolve-tag.outputs.container-tag }}
         docker push $DOCKER_TAG
+        docker push "${DOCKER_REPO]:latest"
 
   # deploy the engine component on GKE using the currently built image
   deploy-engine:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -79,9 +79,6 @@ jobs:
         DOCKER_TAG=$DOCKER_REPO:$(git describe --long --always)
         echo $DOCKER_TAG
         echo "::set-output name=container-tag::${DOCKER_TAG}"
-    - name: "Pull existing latest bentobox-Engine to utilize layers as cache"
-      run: |
-        docker pull "$DOCKER_REPO:latest"
     - name: "Build bentobox-engine"
       run: |
         # build container tagged version given by git describe
@@ -89,6 +86,7 @@ jobs:
         make \
           SIM_BUILD_TYPE=Release \
           SIM_DOCKER_STAGE=release \
+          SIM_DOCKER_CACHE_FROM="${DOCKER_REPO}:latest" \
           SIM_DOCKER=${DOCKER_TAG} \
           build-sim-docker
     - name: "Authenticate with Github Container Registry"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,7 @@
 #
 
 name: "CD Pipeline"
-on: 
+on:
   push:
     branches:
       - master
@@ -74,6 +74,10 @@ jobs:
         DOCKER_TAG=ghcr.io/bentobox-dev/bentobox-engine:$(git describe --long --always)
         echo $DOCKER_TAG
         echo "::set-output name=container-tag::${DOCKER_TAG}"
+    - name: "Pull existing latest bentobox-engine to utilize layers as cache"
+      run: |
+        DOCKER_TAG=${{ steps.resolve-tag.outputs.container-tag }}
+        docker pull $DOCKER_TAG
     - name: "Build bentobox-engine"
       run: |
         # build container tagged version given by git describe
@@ -102,7 +106,7 @@ jobs:
     env:
       PROJECT_ID: ${{ secrets.GKE_PROJECT }}
       GKE_CLUSTER: k8s-bentobox-demo
-      GKE_ZONE: asia-southeast1-c 
+      GKE_ZONE: asia-southeast1-c
     steps:
     - uses: actions/checkout@v2
     # init gcloud CLI
@@ -132,7 +136,7 @@ jobs:
         git diff
         # deploy using kubectl
         ./kustomize build . | kubectl apply -f -
-      
+
   # build and publish the engine component on github container registry
   publish-sdk:
     runs-on: ubuntu-20.04
@@ -152,7 +156,7 @@ jobs:
           # display built artifacts
           ls sdk/dist/
       - name: Publish bentobox-sdk to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.2 
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_TOKEN }}
           packages_dir: sdk/dist/

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,10 +4,14 @@
 #
 
 name: "CD Pipeline"
-on:
-  push:
-    branches:
-      - master
+# TODO(mrzzy): remove this before commit
+#on:
+#  push:
+#    branches:
+#      - master
+on: push
+env:
+  DOCKER_REPO: ghcr.io/bentobox-dev/bentobox-engine
 jobs:
   # builds & publishes docs for the sdk component to Github
   publish-docs-sdk:
@@ -63,7 +67,6 @@ jobs:
     name: "Publish bentobox-engine container to Github Container Registry"
     outputs:
       container-tag: ${{ steps.resolve-tag.outputs.container-tag }}
-      container-repo: ${{ steps.resolve-tag.outputs.container-repo }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -72,15 +75,12 @@ jobs:
     - id: resolve-tag
       name: "Resolve bentobox-engine container tag"
       run: |
-        DOCKER_REPO=ghcr.io/bentobox-dev/bentobox-engine
         DOCKER_TAG=$DOCKER_REPO:$(git describe --long --always)
         echo $DOCKER_TAG
-        echo "::set-output name=container-repo::${DOCKER_REPO}"
         echo "::set-output name=container-tag::${DOCKER_TAG}"
-    - name: "Pull existing latest bentobox-engine to utilize layers as cache"
+    - name: "Pull existing latest bentobox-Engine to utilize layers as cache"
       run: |
-        DOCKER_TAG=${{ steps.resolve-tag.outputs.container-tag }}
-        docker pull $DOCKER_TAG
+        docker pull "$DOCKER_REPO:latest"
     - name: "Build bentobox-engine"
       run: |
         # build container tagged version given by git describe
@@ -99,7 +99,6 @@ jobs:
     - name: "Push bentobox-engine container to Github Container Registry"
       run: |
         # push with both latest and versioned tag
-        DOCKER_REPO=${{ steps.resolve-tag.outputs.container-repo }}
         DOCKER_TAG=${{ steps.resolve-tag.outputs.container-tag }}
         docker push $DOCKER_TAG
         docker push "${DOCKER_REPO]:latest"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,14 +75,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: "Install protoc"
+      - name: "Install protoc & Add ~/.local/bin to PATH"
         run: |
           mkdir bin
           make BIN_DIR=bin dep-protoc
-      - name: "Lint bentobox-sdk"
-        run: |
           # required to place pip bins (ie protoc-gen-mypy) in path for protoc
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: "Lint bentobox-sdk"
+        run: |
           make lint-sdk PROTOC=./bin/protoc
 
   # build & unit tests sdk component

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,12 +76,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: "Install protoc & Add ~/.local/bin to PATH"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: "Install protoc"
         run: |
           mkdir bin
           make BIN_DIR=bin dep-protoc
-          # required to place pip bins (ie protoc-gen-mypy) in path for protoc
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: "Lint bentobox-sdk"
         run: |
           make lint-sdk PROTOC=./bin/protoc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@
 
 name: "CI Pipeline"
 on: push
+env:
+  DOCKER_REPO: ghcr.io/bentobox-dev/bentobox-engine
 jobs:
   # quick check that protos can be compiled by protoc
   # and lint proto formatting
@@ -57,8 +59,7 @@ jobs:
           make lint-sim
       - name: "Pull existing latest bentobox-engine to utilize layers as cache"
         run: |
-          DOCKER_TAG=${{ steps.resolve-tag.outputs.container-tag }}
-          docker pull $DOCKER_TAG
+          docker pull "$DOCKER_REPO:latest"
       - name: "Build bentobox-sim"
         run: |
           # stop at 'build' build stage as it contains the dev tools required to run tests
@@ -134,8 +135,7 @@ jobs:
           make dep-e2e
       - name: "Pull existing latest bentobox-engine to utilize layers as cache"
         run: |
-          DOCKER_TAG=${{ steps.resolve-tag.outputs.container-tag }}
-          docker pull $DOCKER_TAG
+          docker pull "$DOCKER_REPO:latest"
       - name: "Build bentobox-engine"
         run: |
           make SIM_BUILD_TYPE=Release SIM_DOCKER_STAGE=release build-sim-docker

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,20 @@ jobs:
         run: |
           docker run bentobox-sim make test-sim
 
+  # lint the SDK component
+  lint-sdk:
+    needs: check-protos
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Install protoc"
+        run: |
+          mkdir bin
+          make BIN_DIR=bin dep-protoc
+      - name: "Lint bentobox-sdk"
+        run: |
+          make lint-sdk PROTOC=./bin/protoc
+
   # build & unit tests sdk component
   build-test-sdk:
     needs: check-protos
@@ -92,9 +106,6 @@ jobs:
       - name: "Pull dependencies"
         run: |
           make dep-sdk-dev
-      - name: "Lint bentobox-sdk"
-        run: |
-          make lint-sdk
       - name: "Build bentobox-sdk"
         run: |
           make build-sdk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,10 @@ jobs:
       - name: "Lint bentobox-sim"
         run: |
           make lint-sim
+      - name: "Pull existing latest bentobox-engine to utilize layers as cache"
+        run: |
+          DOCKER_TAG=${{ steps.resolve-tag.outputs.container-tag }}
+          docker pull $DOCKER_TAG
       - name: "Build bentobox-sim"
         run: |
           # stop at 'build' build stage as it contains the dev tools required to run tests
@@ -128,7 +132,11 @@ jobs:
       - name: "Pull dependencies"
         run: |
           make dep-e2e
-      - name: "Build bentobox-sim"
+      - name: "Pull existing latest bentobox-engine to utilize layers as cache"
+        run: |
+          DOCKER_TAG=${{ steps.resolve-tag.outputs.container-tag }}
+          docker pull $DOCKER_TAG
+      - name: "Build bentobox-engine"
         run: |
           make SIM_BUILD_TYPE=Release SIM_DOCKER_STAGE=release build-sim-docker
       - name: "Install bentobox-sdk"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,7 @@ jobs:
 
   # lint the SDK component
   lint-sdk:
+    name: "Lint bentobox-sdk"
     needs: check-protos
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python}}
+      - name: "Install protoc"
+        run: |
+          make dep-protoc
       - name: "Pull dependencies"
         run: |
           make dep-sdk-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ name: "CI Pipeline"
 on: push
 env:
   DOCKER_REPO: ghcr.io/bentobox-dev/bentobox-engine
+  DOCKER_BUILDKIT: 1
 jobs:
   # quick check that protos can be compiled by protoc
   # and lint proto formatting

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,8 @@ jobs:
           make BIN_DIR=bin dep-protoc
       - name: "Lint bentobox-sdk"
         run: |
+          # required to place pip bins (ie protoc-gen-mypy) in path for protoc
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
           make lint-sdk PROTOC=./bin/protoc
 
   # build & unit tests sdk component
@@ -100,9 +102,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python}}
-      - name: "Install protoc"
-        run: |
-          make dep-protoc
       - name: "Pull dependencies"
         run: |
           make dep-sdk-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,9 +58,6 @@ jobs:
       - name: "Lint bentobox-sim"
         run: |
           make lint-sim
-      - name: "Pull existing latest bentobox-engine to utilize layers as cache"
-        run: |
-          docker pull "$DOCKER_REPO:latest"
       - name: "Build bentobox-sim"
         run: |
           # stop at 'build' build stage as it contains the dev tools required to run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,9 @@ jobs:
         run: |
           mkdir bin
           make BIN_DIR=bin dep-protoc
+      - name: "Install bentobox-sdk"
+        run: |
+          make install-sdk
       - name: "Lint bentobox-sdk"
         run: |
           make lint-sdk PROTOC=./bin/protoc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,10 @@ jobs:
       - name: "Build bentobox-sim"
         run: |
           # stop at 'build' build stage as it contains the dev tools required to run tests
-          make SIM_BUILD_TYPE=Release SIM_DOCKER_STAGE=build build-sim-docker
+          make SIM_BUILD_TYPE=Debug \
+            SIM_DOCKER_STAGE=build \
+            SIM_DOCKER_CACHE_FROM="${DOCKER_REPO}:latest" \
+            build-sim-docker
       - name: "Unit Test bentobox-sim"
         run: |
           docker run bentobox-sim make test-sim
@@ -149,12 +152,12 @@ jobs:
       - name: "Pull dependencies"
         run: |
           make dep-e2e
-      - name: "Pull existing latest bentobox-engine to utilize layers as cache"
-        run: |
-          docker pull "$DOCKER_REPO:latest"
       - name: "Build bentobox-engine"
         run: |
-          make SIM_BUILD_TYPE=Release SIM_DOCKER_STAGE=release build-sim-docker
+          make SIM_BUILD_TYPE=Release \
+            SIM_DOCKER_STAGE=release \
+            SIM_DOCKER_CACHE_FROM="${DOCKER_REPO}:latest" \
+            build-sim-docker
       - name: "Install bentobox-sdk"
         run: |
           make install-sdk

--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,4 @@ sdk/ChangeLog
 sdk/AUTHORS
 sdk/bento/protos/
 sdk/docs/
+sdk/grpc/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+    - id: check-merge-conflict
+- repo: https://github.com/Yelp/detect-secrets
+  rev: v0.14.3
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json
+- repo: https://github.com/psf/black
+  rev: 20.8b1
+  hooks:
+  -   id: black

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,67 @@
+{
+  "custom_plugin_paths": [],
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2021-02-18T06:17:25Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {},
+  "version": "0.14.3",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/infra/kustomize/engine/deployment.yaml
+++ b/infra/kustomize/engine/deployment.yaml
@@ -1,7 +1,7 @@
 #
 # bentobox engine
 # k8s deployment
-# 
+#
 
 apiVersion: apps/v1
 kind: Deployment

--- a/makefile
+++ b/makefile
@@ -140,6 +140,11 @@ format-sdk: dep-sdk-dev
 lint-sdk: dep-sdk-dev
 	$(BLACK_FMT) --check $(SDK_SRC)/bento
 	$(BLACK_FMT) --check $(SDK_SRC)/tests
+	# mypy requires the type stubs be generated for python protobuf bindings
+	$(FIND_PROTO_SRC) | xargs $(PROTOC) \
+		-I$(PROTO_SRC) \
+		--mypy_out=$(SDK_SRC) \
+		--mypy_grpc_out=$(SDK_SRC)
 	$(MYPY) --config-file $(SDK_SRC)/mypy.ini $(SDK_SRC)/bento
 
 install-sdk:

--- a/makefile
+++ b/makefile
@@ -134,7 +134,7 @@ PIP=python -m pip
 dep-sdk-dev:
 	$(PIP) install -r $(SDK_SRC)/requirements-dev.txt
 
-build-sdk: dep-sdk-dev lint-sdk
+build-sdk: dep-sdk-dev
 	cd $(SDK_SRC) && $(PYTHON) setup.py sdist bdist_wheel
 
 format-sdk: dep-sdk-dev

--- a/makefile
+++ b/makefile
@@ -120,7 +120,7 @@ lint-sim: .clang-format
 SDK_SRC:=sdk
 PYTHON:=python
 BLACK_FMT:=python -m black
-MYPY:=python -m mypy
+MYPY:=mypy
 PYTEST:=python -m pytest -vv
 PDOC:=python -m pdoc --force
 PIP=python -m pip

--- a/makefile
+++ b/makefile
@@ -74,6 +74,9 @@ FIND_SIM_SRC:=$(FIND) $(SIM_SRC_DIRS) -type f \( -name "*.cpp" -o -name "*.h" \)
 SIM_BUILD_TYPE:=Debug
 SIM_DOCKER:=bentobox-sim
 SIM_DOCKER_STAGE:=release
+SIM_DOCKER_CACHE_FROM:=
+SIM_DOCKER_FLAGS:=$(if $(SIM_DOCKER_CACHE_FROM),--cache-from=$(SIM_DOCKER_CACHE_FROM),) \
+	--build-arg BUILDKIT_INLINE_CACHE=1
 SIM_PORT:=54242
 SIM_HOST:=0.0.0.0
 CMAKE_GENERATOR:=Ninja
@@ -91,7 +94,8 @@ build-sim: dep-sim
 		--target $(SIM_TARGET) --target $(SIM_TEST)
 
 build-sim-docker:
-	$(DOCKER) build --target $(SIM_DOCKER_STAGE) -t $(SIM_DOCKER) -f infra/docker/sim/Dockerfile .
+	$(DOCKER) build --target $(SIM_DOCKER_STAGE) $(SIM_DOCKER_FLAGS) \
+		-t $(SIM_DOCKER) -f infra/docker/sim/Dockerfile .
 
 test-sim: build-sim
 	$(SIM_BUILD_DIR)/$(SIM_TEST)

--- a/makefile
+++ b/makefile
@@ -120,7 +120,7 @@ lint-sim: .clang-format
 SDK_SRC:=sdk
 PYTHON:=python
 BLACK_FMT:=python -m black
-MYPY:=mypy
+MYPY:=python -m mypy
 PYTEST:=python -m pytest -vv
 PDOC:=python -m pdoc --force
 PIP=python -m pip

--- a/makefile
+++ b/makefile
@@ -120,6 +120,7 @@ lint-sim: .clang-format
 SDK_SRC:=sdk
 PYTHON:=python
 BLACK_FMT:=python -m black
+MYPY:=python -m mypy
 PYTEST:=python -m pytest -vv
 PDOC:=python -m pdoc --force
 PIP=python -m pip
@@ -139,6 +140,7 @@ format-sdk: dep-sdk-dev
 lint-sdk: dep-sdk-dev
 	$(BLACK_FMT) --check $(SDK_SRC)/bento
 	$(BLACK_FMT) --check $(SDK_SRC)/tests
+	$(MYPY) --config-file $(SDK_SRC)/mypy.ini $(SDK_SRC)/bento
 
 install-sdk:
 	$(PIP) install -e $(SDK_SRC)

--- a/makefile
+++ b/makefile
@@ -151,7 +151,7 @@ lint-sdk: dep-sdk-dev
 		--mypy_grpc_out=$(SDK_SRC)
 	cd $(SDK_SRC) && $(MYPY) --config-file mypy.ini bento
 
-install-sdk:
+install-sdk: dep-sdk-dev
 	$(PIP) install -e $(SDK_SRC)
 
 test-sdk: dep-sdk-dev install-sdk

--- a/makefile
+++ b/makefile
@@ -149,7 +149,7 @@ lint-sdk: dep-sdk-dev
 		-I$(PROTO_SRC) \
 		--mypy_out=$(SDK_SRC) \
 		--mypy_grpc_out=$(SDK_SRC)
-	$(MYPY) --config-file $(SDK_SRC)/mypy.ini $(SDK_SRC)/bento
+	cd $(SDK_SRC) && $(MYPY) --config-file mypy.ini bento
 
 install-sdk:
 	$(PIP) install -e $(SDK_SRC)

--- a/sdk/bento/client.py
+++ b/sdk/bento/client.py
@@ -45,8 +45,6 @@ def raise_native(err: RpcError):
         raise LookupError(err.details())
     elif status == StatusCode.ALREADY_EXISTS:
         raise FileExistsError(err.details())
-    elif status == StatusCode.OUT_OF_RANGE:
-        raise IndexError(err.details())
     else:
         raise RuntimeError(err.details())
 
@@ -143,7 +141,7 @@ class Client:
             response = self.sim_grpc.ListSimulation(ListSimulationReq())
         except RpcError as e:
             raise_native(e)
-        return response.sim_names
+        return list(response.sim_names)
 
     def remove_sim(self, name: str):
         """Remove the simulation with the given name.

--- a/sdk/bento/ecs/base.py
+++ b/sdk/bento/ecs/base.py
@@ -71,14 +71,14 @@ class Entity(ABC):
         pass
 
     @abstractproperty
-    def id(self) -> int:  # type: ignore
+    def id(self) -> int:
         """Get the id of this Entity"""
-        pass
+        return 0  # placeholder to statisfy type checking
 
     @abstractproperty
-    def components(self) -> FrozenSet[Component]:  # type: ignore
+    def components(self) -> FrozenSet[Component]:
         """Get the components attached to this Entity"""
-        pass
+        return FrozenSet()  # placeholder to statisfy type checking
 
     def __getitem__(self, name: Union[str, ComponentDef]) -> Component:
         """Alias for get_component()"""

--- a/sdk/bento/ecs/base.py
+++ b/sdk/bento/ecs/base.py
@@ -4,7 +4,7 @@
 # Base classes
 #
 
-from typing import List, Any, Set, Union
+from typing import FrozenSet, List, Any, Set, Union
 from abc import ABC, abstractmethod, abstractproperty
 
 from bento.spec.ecs import ComponentDef
@@ -76,7 +76,7 @@ class Entity(ABC):
         pass
 
     @abstractproperty
-    def components(self) -> Set[Component]:  # type: ignore
+    def components(self) -> FrozenSet[Component]:  # type: ignore
         """Get the components attached to this Entity"""
         pass
 

--- a/sdk/bento/ecs/grpc.py
+++ b/sdk/bento/ecs/grpc.py
@@ -5,7 +5,7 @@
 #
 
 
-from typing import Any, Set, List
+from typing import Any, FrozenSet, Set, List
 
 from bento.ecs import base
 from bento.types import Type
@@ -91,5 +91,5 @@ class Entity(base.Entity):
         return self.entity_id
 
     @property
-    def components(self) -> Set[Component]:
+    def components(self) -> FrozenSet[Component]:
         return frozenset(self.component_map.values())

--- a/sdk/bento/graph/analyzers.py
+++ b/sdk/bento/graph/analyzers.py
@@ -14,7 +14,7 @@ from math import inf
 from gast import (
     AST,
     Constant,
-    ListAST,
+    List as ListAST,
     Tuple,
     Pass,
     FunctionDef,

--- a/sdk/bento/graph/analyzers.py
+++ b/sdk/bento/graph/analyzers.py
@@ -11,11 +11,10 @@ from copy import deepcopy
 from collections import deque
 from collections.abc import Iterable
 from math import inf
-from typing import List
 from gast import (
     AST,
     Constant,
-    List,
+    ListAST,
     Tuple,
     Pass,
     FunctionDef,
@@ -133,7 +132,7 @@ def analyze_assign(ast: AST) -> AST:
     assign_asts = [n for n in gast.walk(ast) if isinstance(n, assign_types)]
 
     for assign_ast in assign_asts:
-        iterable_types = (List, Tuple)
+        iterable_types = (ListAST, Tuple)
         assign_ast.is_unpack, assign_ast.is_multi = False, False
         if isinstance(assign_ast, Assign):
             # check if this unpacking assignment
@@ -191,7 +190,7 @@ def analyze_const(ast: AST) -> AST:
 
     # recursively walk AST to search for constants
     def walk_const(ast, part_of=None):
-        iterable_types = (List, Tuple)
+        iterable_types = (ListAST, Tuple)
         ignore_types = (Load, Store, Del)
 
         ast.is_constant = False

--- a/sdk/bento/graph/ast.py
+++ b/sdk/bento/graph/ast.py
@@ -247,7 +247,7 @@ def load_ast_module(ast: AST, remove_src: bool = True) -> Union[Any, Tuple[Any, 
         # import the source as a module
         mod_spec = spec_from_file_location("compiled", f.name)
         module = module_from_spec(mod_spec)
-        mod_spec.loader.exec_module(module)
+        mod_spec.loader.exec_module(module)  # type: ignore
     # delete the temporary file manually as NamedTemporaryFile runs into
     # permission issues trying to remove it on Windows.
     if remove_src:

--- a/sdk/bento/graph/compile.py
+++ b/sdk/bento/graph/compile.py
@@ -149,7 +149,7 @@ def compile_graph(
     compiled, src_path = load_ast_module(ast, remove_src=False)
     # allow the use of globals symbols with respect to convert_fn function
     # to be used during graph plotting
-    compiled.build_graph.__globals__.update(convert_fn.__globals__)
+    compiled.build_graph.__globals__.update(convert_fn.__globals__)  # type: ignore
 
     # run build graph function with plotter to build final computation graph
     g = Plotter(entity_defs, component_defs)

--- a/sdk/bento/graph/plotter.py
+++ b/sdk/bento/graph/plotter.py
@@ -40,7 +40,8 @@ class Plotter:
         # collects the graph nodes from operations performed on GraphComponent
         # use OrderedDict to preserve order of operations recorded.
         # key: str attribute ref => value: graph node
-        self.inputs, self.outputs = OrderedDict(), OrderedDict()
+        self.inputs = OrderedDict()  # type: OrderedDict
+        self.outputs = OrderedDict()  # type: OrderedDict
 
         # map component name set to entity
         self.entity_map = {}

--- a/sdk/bento/value.py
+++ b/sdk/bento/value.py
@@ -3,6 +3,7 @@
 # SDK - Value
 #
 
+# type ignore required here as numpy does not have type stubs yet
 import numpy as np  # type: ignore
 from typing import Any
 from inspect import isgenerator

--- a/sdk/bento/value.py
+++ b/sdk/bento/value.py
@@ -3,8 +3,7 @@
 # SDK - Value
 #
 
-# type ignore required here as numpy does not have type stubs yet
-import numpy as np  # type: ignore
+import numpy as np
 from typing import Any
 from inspect import isgenerator
 from bento import types

--- a/sdk/bento/value.py
+++ b/sdk/bento/value.py
@@ -3,7 +3,8 @@
 # SDK - Value
 #
 
-import numpy as np
+# type ignore required here as numpy does not have type stubs yet
+import numpy as np  # type: ignore
 from typing import Any
 from inspect import isgenerator
 from bento import types

--- a/sdk/bento/value.py
+++ b/sdk/bento/value.py
@@ -3,7 +3,7 @@
 # SDK - Value
 #
 
-import numpy as np
+import numpy as np  # type: ignore
 from typing import Any
 from inspect import isgenerator
 from bento import types

--- a/sdk/mypy.ini
+++ b/sdk/mypy.ini
@@ -1,0 +1,5 @@
+[mypy-gast.*]
+ignore_missing_imports = True
+[mypy-astunparse.*]
+ignore_missing_imports = True
+[mypy]

--- a/sdk/requirements-dev.txt
+++ b/sdk/requirements-dev.txt
@@ -31,7 +31,5 @@ typed-ast==1.4.1
 typing-extensions==3.7.4.3
 zipp==3.4.0
 mypy-protobuf==2.4
-types-protobuf==0.1.1
 twine==3.3.0
-mypy==0.800
 grpc-stubs==1.24.5

--- a/sdk/requirements-dev.txt
+++ b/sdk/requirements-dev.txt
@@ -33,3 +33,5 @@ zipp==3.4.0
 mypy-protobuf==2.4
 types-protobuf==0.1.1
 twine==3.3.0
+mypy==0.800
+grpc-stubs==1.24.5

--- a/sdk/requirements-dev.txt
+++ b/sdk/requirements-dev.txt
@@ -13,7 +13,7 @@ Mako==1.1.3
 Markdown==3.3.3
 MarkupSafe==1.1.1
 mypy-extensions==0.4.3
-numpy==1.20.1
+numpy==1.19.4
 packaging==20.4
 pathspec==0.8.1
 pbr==5.5.1

--- a/sdk/requirements-dev.txt
+++ b/sdk/requirements-dev.txt
@@ -13,7 +13,7 @@ Mako==1.1.3
 Markdown==3.3.3
 MarkupSafe==1.1.1
 mypy-extensions==0.4.3
-numpy==1.19.4
+numpy==1.20.1
 packaging==20.4
 pathspec==0.8.1
 pbr==5.5.1

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -2,5 +2,5 @@ gast==0.4.0
 grpcio==1.33.2
 protobuf==3.14.0
 astunparse==1.6.3
-numpy==1.19.4
+numpy==1.20.1
 PyYAML==5.3.1

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -2,5 +2,5 @@ gast==0.4.0
 grpcio==1.33.2
 protobuf==3.14.0
 astunparse==1.6.3
-numpy==1.20.1
+numpy==1.19.4
 PyYAML==5.3.1


### PR DESCRIPTION
### Why we need this PR
Closes #29: Finishes implementing #29. 

### What this PR does 
Add Mypy Static Type Checking:
- Add mypy to project makefile to lint types when linting SDK.
- Fix or ignore existing errors flagged by mypy.
-  Add secrets, end of file, trailing whitespace, merge conflict and secrets as pre-commit checks

Pull latest bentobox-engine Docker image as build cache:
- Adds cache metadata to built images required to use pulled images as cache.
- Replace docker image caching in favor of just pulling the previous docker image.